### PR TITLE
Markdownify everything

### DIFF
--- a/exampleSite/data/aboutSection.yml
+++ b/exampleSite/data/aboutSection.yml
@@ -1,10 +1,14 @@
 ---
 enable: true
 title: About me
-subtitle: Enjoy team diversity and increase their networks among others people in
+subtitle:
+  Enjoy team diversity and increase their networks among others people in
   various fields by provided.
 title2: I design and build ultimate things.
-content: I love to work in User Experience & User Interface designing. Because I love
+content: >
+  ### I design and build ultimate things.
+
+  I love to work in User Experience & User Interface designing. Because I love
   to solve the design problem and find easy and better solutions to solve it. I always
   try my best to make good user interface with the best user experience. I have been
   working as a Visual designer from.

--- a/exampleSite/data/blogSection.yml
+++ b/exampleSite/data/blogSection.yml
@@ -2,5 +2,9 @@
 enable: true
 topTitle: Blog
 title: Recent Article
-subtitle: Enjoy team diversity and increase their networks among others people in various fields by provided.
+content: >
+  # Recent Article
+
+  Enjoy team diversity and increase their networks among others people in various fields by provided.
+
 buttonTarget: blog

--- a/exampleSite/data/hero.yml
+++ b/exampleSite/data/hero.yml
@@ -1,8 +1,10 @@
 ---
 enable: true
-title: Hello, I am Natasha
-subtitle: I am here for your personal business
-description: Enjoy team diversity and increase their networks among others people
+topTitle: Hello, I am Natasha
+content: >
+  # I am here for your personal business
+
+  Enjoy team diversity and increase their networks among others people
   in various fields by
 buttonName: Contact me
 buttonURL: contact

--- a/exampleSite/data/resumeSection.yml
+++ b/exampleSite/data/resumeSection.yml
@@ -19,39 +19,45 @@ tab1Target: education
 tab2Target: experience
 
 education:
-  - title: Master in Arts
-    content: >
+  - content: >
       #### Master in Arts
 
       Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+    time: 2008-2010
+  - content: >
+      #### Master in Arts
 
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
     time: 2008-2010
-  - title: Master in Arts
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+  - content: >
+      #### Master in Arts
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
     time: 2008-2010
-  - title: Master in Arts
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-    time: 2008-2010
-  - title: Master in Arts
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-    time: 2008-2010
-  - title: Master in Arts
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+  - content: >
+      #### Master in Arts
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
     time: 2008-2010
 
 experience:
-  - title: experience
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-    time: 2008-2010
-  - title: experience
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-    time: 2008-2010
-  - title: experience
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-    time: 2008-2010
-  - title: experience
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-    time: 2008-2010
-  - title: experience
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-    time: 2008-2010
+  - content: >
+      #### Umbrella co. 
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+    time: 2016-Present
+  - content: >
+      #### Aperture Science 
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+    time: 2010-2016
+  - content: >
+      #### ACME Inc. 
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+    time: 2005-2010
+  - content: >
+      #### LexCorp 
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+    time: 2001-2005

--- a/exampleSite/data/resumeSection.yml
+++ b/exampleSite/data/resumeSection.yml
@@ -1,10 +1,18 @@
 ---
 enable: true
 topTitle: My Resume
-title: My Expertises
-subtitle: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
-subsubtitle: Magna aliquyam erat, sed diam voluptua. At vero eos accusam justo.
+# Using "&nbsp;" is a way to force extra line breaks.
+# See: https://discourse.gohugo.io/t/does-hardlinebreak-works-with-multiple-line-breaks/12522
+content: >
+  # My Expertises
 
+  Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore  
+
+
+  &nbsp;
+
+
+  Magna aliquyam erat, sed diam voluptua. At vero eos accusam justo.
 tab1Name: Education
 tab2Name: Experiences
 tab1Target: education
@@ -12,7 +20,11 @@ tab2Target: experience
 
 education:
   - title: Master in Arts
-    content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+    content: >
+      #### Master in Arts
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+
     time: 2008-2010
   - title: Master in Arts
     content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam

--- a/exampleSite/data/serviceSection.yml
+++ b/exampleSite/data/serviceSection.yml
@@ -1,31 +1,45 @@
 ---
 enable: true
 topTitle: Working Area
-title: Creative Services
-subtitle: Enjoy team diversity and increase their networks among others people in
+content: >
+  # Creative Services
+
+  Enjoy team diversity and increase their networks among others people in
   various fields by provided.
 service:
-- title: UI/UX Design
-  content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
-    tempor invidunt ut labore et dolore magna aliquyam erat.
-  image: images/service/ui-ux.svg
-- title: Web Development
-  content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
-    tempor invidunt ut labore et dolore magna aliquyam erat.
-  image: images/service/web.svg
-- title: Creative Design
-  content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
-    tempor invidunt ut labore et dolore magna aliquyam erat.
-  image: images/service/creative.svg
-- title: Branding
-  content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
-    tempor invidunt ut labore et dolore magna aliquyam erat.
-  image: images/service/branding.svg
-- title: UI/UX Design
-  content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
-    tempor invidunt ut labore et dolore magna aliquyam erat.
-  image: images/service/ui-ux.svg
-- title: Web Development
-  content: Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
-    tempor invidunt ut labore et dolore magna aliquyam erat.
-  image: images/service/web.svg
+  - content: >
+      #### UI/UX Design 
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
+      tempor invidunt ut labore et dolore magna aliquyam erat.
+    image: images/service/ui-ux.svg
+  - content: >
+      #### Web Development 
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
+      tempor invidunt ut labore et dolore magna aliquyam erat.
+    image: images/service/web.svg
+  - content: >
+      #### Creative Design 
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
+      tempor invidunt ut labore et dolore magna aliquyam erat.
+    image: images/service/creative.svg
+  - content: >
+      #### Branding
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
+      tempor invidunt ut labore et dolore magna aliquyam erat.
+    image: images/service/branding.svg
+  - content: >
+      #### UI/UX Design
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
+      tempor invidunt ut labore et dolore magna aliquyam erat.
+    image: images/service/ui-ux.svg
+  - content: >
+      #### Web Development
+
+      Lorem ipsum dolor sit amet conset sadipscing elitr, sed diam nonumy eirmod
+      tempor invidunt ut labore et dolore magna aliquyam erat.
+    image: images/service/web.svg

--- a/exampleSite/data/skillSection.yml
+++ b/exampleSite/data/skillSection.yml
@@ -1,8 +1,11 @@
 ---
 enable: true
 topTitle: My Skills
-title: Why hire me for your next project?
-subtitle: My goal is to build a strong supportive professional network among all freelancers and startups in order to improve their performance.
+content: >
+  # Why hire me for your next project?
+
+  My goal is to build a strong supportive professional network among all freelancers and startups in order to improve their performance.
+
 image: images/skill/skill_image.jpg
 
 skill:

--- a/layouts/partials/aboutSection.html
+++ b/layouts/partials/aboutSection.html
@@ -1,53 +1,55 @@
 {{ with .Site.Data.aboutSection }}
-    {{ if .enable }}
-        <section class="section about" id="about">
-            <div class="container">
-                <div class="row text-center">
-                    <div class="col-lg-6 offset-lg-3">
-                        <div class="about_header">
-                            <span>About</span>
-                            <h1> {{ .title }} </h1>
-                            <p> {{ .subtitle }} </p>
+{{ if .enable }}
+<section class="section about" id="about">
+    <div class="container">
+        <div class="row text-center">
+            <div class="col-lg-6 offset-lg-3">
+                <div class="about_header">
+                    <span>About</span>
+                    <h1> {{ .title }} </h1>
+                    <p> {{ .subtitle }} </p>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="about_content">
+                    <div class="about_content-thumb">
+                        <div class="about-svg">
+                            <img src="images/hero/figure-svg.svg" alt="figure-svg">
+                        </div>
+                        <div class="about_content-thumb-image">
+                            <img src="{{ .image | absURL }}" alt="about-img"
+                                style='-webkit-mask: url({{"images/about/about-mask-svg.svg" | absURL}}); -webkit-mask-size: contain;'>
                         </div>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="about_content">
-                            <div class="about_content-thumb">
-                                <div class="about-svg">
-                                    <img src="images/hero/figure-svg.svg" alt="figure-svg">
-                                </div>
-                                <div class="about_content-thumb-image">
-                                    <img src="{{ .image | absURL }}" alt="about-img" style='-webkit-mask: url({{"images/about/about-mask-svg.svg" | absURL}}); -webkit-mask-size: contain;'>
-                                </div>
-                            </div>
-                            <div class="about_content-inner">
-                                <div class="about_content-inner-blob">
-                                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
-                                        <defs>
-                                        <linearGradient id="c" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
-                                            <stop offset="0" stop-color="#f1f6f9"/>
-                                            <stop offset="1" stop-color="#f1f6f9" stop-opacity="0"/>
-                                        </linearGradient>
-                                        </defs>
-                                        <g data-name="blob-shape (3)">
-                                            <path class="blob" fill="url(#c)" d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z"/>
-                                        </g>
-                                    </svg>
-                                </div>
-                                <h3>{{ .title2 }}</h3>
-                                <p>{{ .content }}</p>
-                                <ul>
-                                    <li><a class="active" href="{{ .button1Target | absURL }}">{{ .button1Name }}</a></li>
-                                    <li><a href="{{ .button2Target | absURL }}"> {{ .button2Name }} </a></li>
-                                </ul>
-                            </div>
+                    <div class="about_content-inner">
+                        <div class="about_content-inner-blob">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+                                viewBox="0 0 600 600">
+                                <defs>
+                                    <linearGradient id="c" x1="0.929" y1="0.111" x2="0.263" y2="0.935"
+                                        gradientUnits="objectBoundingBox">
+                                        <stop offset="0" stop-color="#f1f6f9" />
+                                        <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
+                                    </linearGradient>
+                                </defs>
+                                <g data-name="blob-shape (3)">
+                                    <path class="blob" fill="url(#c)"
+                                        d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+                                </g>
+                            </svg>
                         </div>
+                        {{ .content | markdownify}}
+                        <ul>
+                            <li><a class="active" href="{{ .button1Target | absURL }}">{{ .button1Name }}</a></li>
+                            <li><a href="{{ .button2Target | absURL }}"> {{ .button2Name }} </a></li>
+                        </ul>
                     </div>
                 </div>
             </div>
-        </section>
-    {{ end }}
+        </div>
+    </div>
+</section>
 {{ end }}
-        
+{{ end }}

--- a/layouts/partials/blogSection.html
+++ b/layouts/partials/blogSection.html
@@ -1,5 +1,5 @@
 {{ with .Site.Data.blogSection }}
-    {{ if .enable }}
+{{ if .enable }}
 <section class="section blog" id="blog">
   <div class="blog__shape">
     <img src="images/blog/blog-shape.svg" alt="blog shape" />
@@ -9,8 +9,7 @@
       <div class="col-lg-6">
         <div class="blog__header">
           <span>{{ .topTitle }}</span>
-          <h1> {{ .title }} </h1>
-          <p> {{ .subtitle }} </p>
+          {{ .content | markdownify }}
         </div>
       </div>
       <div class="col-lg-6">
@@ -34,7 +33,7 @@
         </div>
       </div>
       {{ end }}
-      
+
     </div>
     <div class="row">
       <div class="col-lg-12">

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -1,96 +1,65 @@
 {{ with .Site.Data.hero }}
-  {{ if .enable }}
-    <section class="hero" id="home">
-      <div class="hero_background-svg">
-        <svg viewBox="0 0 1437 1180">
-          <path
-            fill="#f1f6f9"
-            d="M0 0h1377l60 1010a120 120 0 01-120 120L0 1180z"
-            data-name="Path 1350"
-          />
-        </svg>
-      </div>
-      <div class="hero_footer-svg">
-        <img src="images/hero/figure-svg.svg" alt="" />
-      </div>
-      <div class="container">
-        <div class="row align-items-center">
-          <div class="col-lg-6">
-            <div class="hero_content">
-              <div class="hero_blob">
-                <svg viewBox="0 0 550 550">
-                  <defs>
-                    <linearGradient
-                      id="a"
-                      x1=".069"
-                      x2=".753"
-                      y1=".116"
-                      y2=".858"
-                      gradientUnits="objectBoundingBox"
-                    >
-                      <stop offset="0" stop-color="#fff" />
-                      <stop offset="1" stop-color="#fff" stop-opacity=".012" />
-                    </linearGradient>
-                  </defs>
-                  <g data-name="blob-shape (3)">
-                    <path
-                      class="blob"
-                      fill="url(#a)"
-                      d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z"
-                    />
-                  </g>
-                </svg>
-              </div>
-              <span>{{ .title }}</span>
-              <h1>{{ .subtitle }}</h1>
-              <p>
-                {{ .description }}
-              </p>
-              <a href="{{ .buttonURL | absURL }}">{{ .buttonName }}</a>
-            </div>
+{{ if .enable }}
+<section class="hero" id="home">
+  <div class="hero_background-svg">
+    <svg viewBox="0 0 1437 1180">
+      <path fill="#f1f6f9" d="M0 0h1377l60 1010a120 120 0 01-120 120L0 1180z" data-name="Path 1350" />
+    </svg>
+  </div>
+  <div class="hero_footer-svg">
+    <img src="images/hero/figure-svg.svg" alt="" />
+  </div>
+  <div class="container">
+    <div class="row align-items-center">
+      <div class="col-lg-6">
+        <div class="hero_content">
+          <div class="hero_blob">
+            <svg viewBox="0 0 550 550">
+              <defs>
+                <linearGradient id="a" x1=".069" x2=".753" y1=".116" y2=".858" gradientUnits="objectBoundingBox">
+                  <stop offset="0" stop-color="#fff" />
+                  <stop offset="1" stop-color="#fff" stop-opacity=".012" />
+                </linearGradient>
+              </defs>
+              <g data-name="blob-shape (3)">
+                <path class="blob" fill="url(#a)"
+                  d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+              </g>
+            </svg>
           </div>
-          <div class="col-lg-6">
-            <div class="hero_figure">
-              <div class="figure-svg">
-                <img src="images/hero/figure-svg.svg" alt="figure-svg" />
-              </div>
-              <img
-                src="{{ .image | absURL }}"
-                alt="hero-image"
-                style='
+          <span>{{ .topTitle }}</span>
+          {{ .content | markdownify }}
+          <p></p> <!-- I'm unsure why this <p> is needed -->
+          <a href="{{ .buttonURL | absURL }}">{{ .buttonName }}</a>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="hero_figure">
+          <div class="figure-svg">
+            <img src="images/hero/figure-svg.svg" alt="figure-svg" />
+          </div>
+          <img src="{{ .image | absURL }}" alt="hero-image" style='
                   -webkit-mask: url({{"images/hero/hero-mask-svg.png" | absURL }});
                   -webkit-mask-repeat: no-repeat;
                   -webkit-mask-size: contain;
                   -webkit-mask-position: center center;
-                '
-              />
-              <div class="hero_figure-popup">
-                <div class="thumb">
-                  <img src="{{ .videoThumb }}" alt="popup" />
-                </div>
-                <a
-                  href="{{ .videoURL }}"
-                  type="button"
-                  class="popup-button"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="21"
-                    height="24"
-                    viewBox="0 0 21 24"
-                  >
-                    <path
-                      fill="#5d78ff"
-                      d="M17.961 10.264a2 2 0 010 3.473L2.992 22.29A2 2 0 010 20.554V3.446A2 2 0 012.992 1.71z"
-                      data-name="Polygon 4"
-                    />
-                  </svg>
-                </a>
-              </div>
+                ' />
+          <div class="hero_figure-popup">
+            <div class="thumb">
+              <img src="{{ .videoThumb }}" alt="popup" />
             </div>
+            <a href="{{ .videoURL }}" type="button" class="popup-button">
+              <svg xmlns="http://www.w3.org/2000/svg" width="21" height="24" viewBox="0 0 21 24">
+                <path fill="#5d78ff"
+                  d="M17.961 10.264a2 2 0 010 3.473L2.992 22.29A2 2 0 010 20.554V3.446A2 2 0 012.992 1.71z"
+                  data-name="Polygon 4" />
+              </svg>
+            </a>
           </div>
         </div>
       </div>
-    </section>
-  {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }}
 {{ end }}

--- a/layouts/partials/resumeSection.html
+++ b/layouts/partials/resumeSection.html
@@ -1,51 +1,46 @@
 {{ with .Site.Data.resumeSection }}
-    {{ if .enable }}
-        <section class="section resume" id="resume">
-            <div class="resume__background"></div>
-            <div class="container">
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="resume__heading">
-                            <span>{{ .topTitle }}</span>
-                            <h1>{{ .title }}</h1>
-                            <p> {{ .subtitle }} </p><br><br>
-                            <p> {{ .subsubtitle }} </p>
-                            <ul class="nav nav-tabs">
-                                <li><a href="#{{.tab1Target}}" class="active" data-toggle="tab">{{ .tab1Name }}</a></li>
-                                <li><a href="#{{.tab2Target}}" data-toggle="tab">{{ .tab2Name }}</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="col-lg-6">
-                        <div class="tab-content ">
-                            <div class="resume__education tab-pane active" id="{{.tab1Target}}">
-                                {{ $Section := .education }}
-                                {{ range $Section }}
-                                    <div class="resume__education_item">
-                                        <span> {{ .time }} </span>
-                                        <h4> {{ .title }} </h4>
-                                        <p> {{ .content }} </p>
-                                    </div>
-                                {{ end }}
-                            
-                            </div>
-
-                            <div class="resume__education tab-pane" id="{{.tab2Target}}">
-                                {{ $Section := .experience }}
-                                {{ range $Section }}
-                                    <div class="resume__education_item">
-                                        <span> {{ .time }} </span>
-                                        <h4> {{ .title }} </h4>
-                                        <p> {{ .content }} </p>
-                                    </div>
-                                {{ end }}   
-                            </div>
-
-                        </div>
-                    </div>
+{{ if .enable }}
+<section class="section resume" id="resume">
+    <div class="resume__background"></div>
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-6">
+                <div class="resume__heading">
+                    <span>{{ .topTitle }}</span>
+                    {{ .content | markdownify }}
+                    <ul class="nav nav-tabs">
+                        <li><a href="#{{.tab1Target}}" class="active" data-toggle="tab">{{ .tab1Name }}</a></li>
+                        <li><a href="#{{.tab2Target}}" data-toggle="tab">{{ .tab2Name }}</a></li>
+                    </ul>
                 </div>
             </div>
-        </section>
-    {{ end }}
+            <div class="col-lg-6">
+                <div class="tab-content ">
+                    <div class="resume__education tab-pane active" id="{{.tab1Target}}">
+                        {{ $Section := .education }}
+                        {{ range $Section }}
+                        <div class="resume__education_item">
+                            <span> {{ .time }} </span>
+                            {{ .content | markdownify }}
+                        </div>
+                        {{ end }}
+
+                    </div>
+
+                    <div class="resume__education tab-pane" id="{{.tab2Target}}">
+                        {{ $Section := .experience }}
+                        {{ range $Section }}
+                        <div class="resume__education_item">
+                            <span> {{ .time }} </span>
+                            {{ .content | markdownify }}
+                        </div>
+                        {{ end }}
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 {{ end }}
-        
+{{ end }}

--- a/layouts/partials/serviceSection.html
+++ b/layouts/partials/serviceSection.html
@@ -1,63 +1,66 @@
 {{ with .Site.Data.serviceSection }}
-    {{ if .enable }}
-        <section class="section service" id="service">
-            <div class="service__background">
-                <svg viewBox="0 0 1283 1126">
-                    <path fill="#f1f6f9" d="M100 0h1183v1126l-1183-80A100 100 0 010 946V100A100 100 0 01100 0z" data-name="Path 1369"/>
-                </svg>
-            </div>
-            <div class="service__background_shape">
-                <svg viewBox="0 0 550 550">
-                    <defs>
-                        <linearGradient id="b" x1="0.209" y1="0.085" x2="1.071" y2="1.164" gradientUnits="objectBoundingBox">
-                            <stop offset="0" stop-color="#f1f6f9"/>
-                            <stop offset="1" stop-color="#f1f6f9" stop-opacity="0"/>
-                        </linearGradient>
-                    </defs>
-                    <g data-name="blob-shape (3)">
-                    <path class="blob" fill="url(#b)" d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z"/>
-                    </g>
-                </svg>
-            </div>
+{{ if .enable }}
+<section class="section service" id="service">
+    <div class="service__background">
+        <svg viewBox="0 0 1283 1126">
+            <path fill="#f1f6f9" d="M100 0h1183v1126l-1183-80A100 100 0 010 946V100A100 100 0 01100 0z"
+                data-name="Path 1369" />
+        </svg>
+    </div>
+    <div class="service__background_shape">
+        <svg viewBox="0 0 550 550">
+            <defs>
+                <linearGradient id="b" x1="0.209" y1="0.085" x2="1.071" y2="1.164" gradientUnits="objectBoundingBox">
+                    <stop offset="0" stop-color="#f1f6f9" />
+                    <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
+                </linearGradient>
+            </defs>
+            <g data-name="blob-shape (3)">
+                <path class="blob" fill="url(#b)"
+                    d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+            </g>
+        </svg>
+    </div>
 
-            <div class="service__background_pattern">
-                <img src="images/service/background-pattern.svg" alt="background-pattern">
-            </div>
+    <div class="service__background_pattern">
+        <img src="images/service/background-pattern.svg" alt="background-pattern">
+    </div>
 
-            <div class="container">
-                <div class="row">
-                    <div class="col-lg-6 col-md-12 col-sm-12">
-                        <div class="service__header">
-                            <span>{{ .topTitle }}</span>
-                            <h1>{{ .title }}</h1>
-                            <p> {{ .subtitle }} </p>
-                        </div>
-                    </div>
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-6 col-md-12 col-sm-12">
+                <div class="service__header">
+                    <span>{{ .topTitle }}</span>
+                    {{ .content | markdownify }}
                 </div>
-                <div class="row">
-                    <div class="col-12">
-                        <div class="service__slider">
-                            {{ $Section := .service }}
-                            {{ range $Section }}
-                            <div class="service__slider_item">
-                                <div class="service__slider_item-icon">
-                                    <div class="icon-background">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="122.457" height="109.702" viewBox="0 0 122.457 109.702">
-                                            <path fill="#f1f6f9" d="M49.855527 9.984102c-4.337424-.815024-8.766002-1.633779-13.152776-1.113889-8.196034.975107-15.344329 6.696991-19.41555 13.879649s-5.363288 15.655094-5.187042 23.907191c.156996 7.385448 1.479849 14.875357 4.972905 21.38465s9.337384 11.961229 16.458344 13.922244c4.833752 1.331211 10.056683 1.044827 14.74081 2.829827 7.560693 2.881382 12.209757 10.489626 19.01235 14.870016a25.650039 25.650039 0 0024.16316 1.698928c8.342551-3.846451 14.03857-12.107291 16.641338-20.918947s2.471077-18.187687 1.756125-27.346305c-.843101-10.912846-3.01686-22.783019-11.354287-29.869462-6.037066-5.130853-14.208558-6.772976-21.995428-8.235353z" data-name="Path 1354"/>
-                                        </svg>
-                                    </div>
-                                    <div class="icon">
-                                        <img src=" {{ .image | absURL }} " alt="ui-ux">
-                                    </div>
-                                </div>
-                                <h4> {{ .title }} </h4>
-                                <p> {{ .content }} </p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
+                <div class="service__slider">
+                    {{ $Section := .service }}
+                    {{ range $Section }}
+                    <div class="service__slider_item">
+                        <div class="service__slider_item-icon">
+                            <div class="icon-background">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="122.457" height="109.702"
+                                    viewBox="0 0 122.457 109.702">
+                                    <path fill="#f1f6f9"
+                                        d="M49.855527 9.984102c-4.337424-.815024-8.766002-1.633779-13.152776-1.113889-8.196034.975107-15.344329 6.696991-19.41555 13.879649s-5.363288 15.655094-5.187042 23.907191c.156996 7.385448 1.479849 14.875357 4.972905 21.38465s9.337384 11.961229 16.458344 13.922244c4.833752 1.331211 10.056683 1.044827 14.74081 2.829827 7.560693 2.881382 12.209757 10.489626 19.01235 14.870016a25.650039 25.650039 0 0024.16316 1.698928c8.342551-3.846451 14.03857-12.107291 16.641338-20.918947s2.471077-18.187687 1.756125-27.346305c-.843101-10.912846-3.01686-22.783019-11.354287-29.869462-6.037066-5.130853-14.208558-6.772976-21.995428-8.235353z"
+                                        data-name="Path 1354" />
+                                </svg>
                             </div>
-                            {{ end }}
+                            <div class="icon">
+                                <img src=" {{ .image | absURL }} " alt="ui-ux">
+                            </div>
                         </div>
+                        {{ .content | markdownify }}
                     </div>
+                    {{ end }}
                 </div>
             </div>
-        </section>
-    {{ end }}
-{{ end }}      
+        </div>
+    </div>
+</section>
+{{ end }}
+{{ end }}

--- a/layouts/partials/skillSection.html
+++ b/layouts/partials/skillSection.html
@@ -39,8 +39,7 @@
                 <div class="skill__progress">
                     <div class="skill__progress_heading">
                         <span>{{ .topTitle }}</span>
-                        <h1> {{ .title }} </h1>
-                        <p> {{ .subtitle }} </p>
+                        {{ .content | markdownify }}
                     </div>
                     {{ $section := .skill }}
                     {{ range $section }}

--- a/layouts/partials/testimonialSection.html
+++ b/layouts/partials/testimonialSection.html
@@ -1,45 +1,47 @@
 {{ with .Site.Data.testimonialSection }}
-    {{ if .enable }}
-        <section class="section testimonial">
-            <div class="testimonial__background_shape">
-                <svg viewBox="0 0 1920 79">
-                    <path d="M0 0h1920v79L0 0z" data-name="Path 1450" />
-                </svg>
-            </div>
-            <div class="container">
-                <div class="row text-center">
-                    <div class="col-lg-6 offset-lg-3">
-                        <div class="testimonial__header">
-                            <span>{{ .topTitle }}</span>
-                            <h1>{{ .title }}</h1>
-                        </div>
-                    </div>
+{{ if .enable }}
+<section class="section testimonial">
+    <div class="testimonial__background_shape">
+        <svg viewBox="0 0 1920 79">
+            <path d="M0 0h1920v79L0 0z" data-name="Path 1450" />
+        </svg>
+    </div>
+    <div class="container">
+        <div class="row text-center">
+            <div class="col-lg-6 offset-lg-3">
+                <div class="testimonial__header">
+                    <span>{{ .topTitle }}</span>
+                    <h1>{{ .title }}</h1>
                 </div>
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="testimonial__slider">
-                            {{ $section := .testimonial }}
-                            {{ range $section }}
-                                <div class="testimonial__slider_item">
-                                    <ul class="testimonial__slider_item-rating">
-                                        {{ $rating := .star | int }}
-                                        {{ $rating := sub $rating 1 }}
-                                        {{ range $i, $sequence := (seq 5) }} 
-                                            {{ if le $i $rating }}
-                                                <li><i class="fa fa-star"></i></li>
-                                            {{ else }}
-                                                <li><i class="fa fa-star inactive"></i></li>
-                                            {{ end }}
-                                        {{ end }}
-                                    </ul>
-                                    <p class="testimonial__slider_item-content"> {{ .comment }} </p>
-                                    <p class="testimonial__slider_item-author"><span>{{ .name }}</span> | {{ .time }}</p>
-                                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="testimonial__slider">
+                    {{ $section := .testimonial }}
+                    {{ range $section }}
+                    <div class="testimonial__slider_item">
+                        {{ if .star }}
+                        <ul class="testimonial__slider_item-rating">
+                            {{ $rating := .star | int }}
+                            {{ $rating := sub $rating 1 }}
+                            {{ range $i, $sequence := (seq 5) }}
+                            {{ if le $i $rating }}
+                            <li><i class="fa fa-star"></i></li>
+                            {{ else }}
+                            <li><i class="fa fa-star inactive"></i></li>
                             {{ end }}
-                        </div>
+                            {{ end }}
+                        </ul>
+                        {{ end }}
+                        <p class="testimonial__slider_item-content"> {{ .comment | markdownify }} </p>
+                        <p class="testimonial__slider_item-author"><span>{{ .name }}</span> | {{ .time }}</p>
                     </div>
+                    {{ end }}
                 </div>
             </div>
-        </section>
-    {{ end }}
+        </div>
+    </div>
+</section>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
This PR enable markdown formatting for most of the text-blocks on the landing page.

This allows you to do stuff like *italicize words* in the about section:
```yaml
content: >
  ### I design and build ultimate things.
  
  I *love* to work in User Experience & User Interface designing.
```

Unrelated to that, I updated `testimonialSection.html` so that when you don't provide a `stars:` in the testimonial section, it doesn't show the stars...  But I was too lazy to make a separate PR.

**Note:** My IDE reformatted the `.html` files, idk if you want to bother to undo that?  Or I can reformat them if you tell me which formatter you like to use.