### PR TITLE
🎨 Hide video if none configured

### DIFF
--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -60,7 +60,7 @@
               </svg>
             </a>
           </div>
-          {{end}}
+          {{ end }}
         </div>
       </div>
     </div>

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -46,6 +46,8 @@
                   -webkit-mask-size: contain;
                   -webkit-mask-position: center center;
                 ' />
+
+          {{ if .videoURL }}
           <div class="hero_figure-popup">
             <div class="thumb">
               <img src="{{ .videoThumb }}" alt="popup" />
@@ -58,6 +60,7 @@
               </svg>
             </a>
           </div>
+          {{end}}
         </div>
       </div>
     </div>


### PR DESCRIPTION
In some cases the user might not populated any value for the VideoURL in the config.
In such cases it would be a good idea to hide this block.