### PR TITLE
number's leading zeros removed

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -17,7 +17,7 @@ function PageLoad() {
 
   // Percentage Increment Animation
   var PercentageID = $("#precent"),
-    start = 001,
+    start = 1,
     end = 100,
     durataion = time;
   animateValue(PercentageID, start, end, durataion);
@@ -69,7 +69,7 @@ $(document).ready(function () {
   // Smooth scrolling
   var scrollLink = $(".scroll");
   scrollLink.click(function (e) {
-    let elem = $(this.hash)
+    let elem = $(this.hash);
     if (elem.length) {
       e.preventDefault();
       $("body,html").animate(


### PR DESCRIPTION
The leading zeros of a number caused js minification error in newer version of hugo(e.g. 0.81).