### PR TITLE
fix the footer background spill up at 600px width

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <section class="footer" id="contact">
 	<div class="footer__background_shape">
-		<svg viewBox="0 0 1920 79">
+		<svg>
 			<path d="M0 0h1920v79L0 0z" data-name="Path 1450" />
 		</svg>
 	</div>


### PR DESCRIPTION
The footer background spills upwards above the white triangle mask when the website is about 600 pixels in width. This commit fixes that problem.