### PR TITLE
Add Skills onto the site Main Menu

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -25,13 +25,17 @@ name = "Resume"
 url = "#resume"
 weight = 5
 [[menu.main]]
+name = "Skills"
+url = "#skills"
+weight = 6
+[[menu.main]]
 name = "Blog"
 url = "#blog"
-weight = 6
+weight = 7
 [[menu.main]]
 name = "Contact"
 url = "#contact"
-weight = 7
+weight = 8
 
 # Sitemap Menu
 [[menu.sitemap]]

--- a/layouts/partials/skillSection.html
+++ b/layouts/partials/skillSection.html
@@ -1,6 +1,6 @@
 {{ with .Site.Data.skillSection }}
 {{ if .enable }}
-<section class="section skill">
+<section class="section skill", id="skills>
     <div class="skill__background_shape">
         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
             <defs>

--- a/layouts/partials/skillSection.html
+++ b/layouts/partials/skillSection.html
@@ -1,6 +1,6 @@
 {{ with .Site.Data.skillSection }}
 {{ if .enable }}
-<section class="section skill", id="skills>
+<section class="section skill", id="skills">
     <div class="skill__background_shape">
         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
             <defs>


### PR DESCRIPTION
This PR adds Skills button on the site Main Menu that links to the Skills section. Closes https://github.com/StaticMania/portio-hugo/issues/50