### PR TITLE
Add support for taxonomies, reading time and date on blog post

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,78 @@
+{{ define "main" }}
+
+{{ partial "head.html" . }}
+
+{{ $baseurl := .Site.BaseURL }}
+<!-- <h1>{{ .Title }}</h1> -->
+
+<header class="breadCrumb">
+    <div class="svg-img">
+        <img src="images/hero/figure-svg.svg" alt="">
+    </div>
+    <div class="animate-shape">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
+            <defs>
+                <linearGradient id="d" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
+                    <stop offset="0" stop-color="#f1f6f9" />
+                    <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
+                </linearGradient>
+            </defs>
+            <g data-name="blob-shape (3)">
+                <path class="blob" fill="url(#d)"
+                    d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+            </g>
+        </svg>
+    </div>
+    <div class="animate-pattern">
+        <img src={{"images/service/background-pattern.svg" | absURL }} alt="background-shape">
+    </div>
+    <div class="container">
+        <div class="row">
+            <div class="col-12 text-center">
+                <h3 class="breadCrumb__title">{{ .Title }}</h3>
+                <nav aria-label="breadcrumb" class="d-flex justify-content-center">
+                    <ol class="breadcrumb align-items-center">
+                        <li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
+    </div>
+</header>
+
+
+<section class="section blog-page">
+    <div class="container">
+        {{ $plural := .Data.Plural }}
+        {{ range $key, $value := .Data.Terms }}
+        <a href="{{ $baseurl }}/{{ $plural }}/{{ $key }}">{{ $key }}</a>
+        <br>
+        {{ end }}
+    </div>
+</section>
+
+<!-- <section>
+    <ul id="all-taxonomies">
+        {{ range $taxonomy_term, $taxonomy := .Site.Taxonomies }}
+            {{ with $.Site.GetPage (printf "/%s" $taxonomy_term) }}
+                <li><a href="{{ .Permalink }}">{{ $taxonomy_term }}</a>
+                    <ul>
+                        {{ range $key, $value := $taxonomy }}
+                            <li>{{ $key }}</li>
+                            <ul>
+                                {{ range $value.Pages }}
+                                    <li hugo-nav="{{ .RelPermalink}}">
+                                        <a href="{{ .Permalink}}">{{ .LinkTitle }}</a>
+                                    </li>
+                                {{ end }}
+                            </ul>
+                        {{ end }}
+                    </ul>
+                </li>
+            {{ end }}
+        {{ end }}
+    </ul>
+</section> -->
+
+{{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,7 +3,6 @@
 {{ partial "head.html" . }}
 
 {{ $baseurl := .Site.BaseURL }}
-<!-- <h1>{{ .Title }}</h1> -->
 
 <header class="breadCrumb">
     <div class="svg-img">
@@ -51,28 +50,5 @@
         {{ end }}
     </div>
 </section>
-
-<!-- <section>
-    <ul id="all-taxonomies">
-        {{ range $taxonomy_term, $taxonomy := .Site.Taxonomies }}
-            {{ with $.Site.GetPage (printf "/%s" $taxonomy_term) }}
-                <li><a href="{{ .Permalink }}">{{ $taxonomy_term }}</a>
-                    <ul>
-                        {{ range $key, $value := $taxonomy }}
-                            <li>{{ $key }}</li>
-                            <ul>
-                                {{ range $value.Pages }}
-                                    <li hugo-nav="{{ .RelPermalink}}">
-                                        <a href="{{ .Permalink}}">{{ .LinkTitle }}</a>
-                                    </li>
-                                {{ end }}
-                            </ul>
-                        {{ end }}
-                    </ul>
-                </li>
-            {{ end }}
-        {{ end }}
-    </ul>
-</section> -->
 
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,28 +3,7 @@
 {{ partial "head.html" . }}
 
 {{ $baseurl := .Site.BaseURL }}
-
 <header class="breadCrumb">
-    <div class="svg-img">
-        <img src="images/hero/figure-svg.svg" alt="">
-    </div>
-    <div class="animate-shape">
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
-            <defs>
-                <linearGradient id="d" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
-                    <stop offset="0" stop-color="#f1f6f9" />
-                    <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
-                </linearGradient>
-            </defs>
-            <g data-name="blob-shape (3)">
-                <path class="blob" fill="url(#d)"
-                    d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
-            </g>
-        </svg>
-    </div>
-    <div class="animate-pattern">
-        <img src={{"images/service/background-pattern.svg" | absURL }} alt="background-shape">
-    </div>
     <div class="container">
         <div class="row">
             <div class="col-12 text-center">
@@ -37,18 +16,45 @@
                 </nav>
             </div>
         </div>
+        <div class="row">
+            <div class="col-12 text-center">
+                <section class="section blog-page">
+                    <div class="container">
+                        {{ $plural := .Data.Plural }}
+                        {{ range $key, $value := .Data.Terms }}
+                        <a href="{{ $baseurl }}/{{ $plural }}/{{ $key }}">{{ $key }}</a>
+                        <br>
+                        {{ end }}
+                    </div>
+                </section>
+            </div>
+        </div>
     </div>
 </header>
 
-
-<section class="section blog-page">
-    <div class="container">
-        {{ $plural := .Data.Plural }}
-        {{ range $key, $value := .Data.Terms }}
-        <a href="{{ $baseurl }}/{{ $plural }}/{{ $key }}">{{ $key }}</a>
-        <br>
-        {{ end }}
+<section class="section singleBlog">
+    <div class="svg-img">
+      <img src={{ "images/hero/figure-svg.svg" | absURL }} alt="">
     </div>
-</section>
+    <div class="animate-shape">
+      <img src={{ "images/skill/skill-background-shape.svg" | absURL }} alt="">
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
+        <defs>
+          <linearGradient id="d" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
+            <stop offset="0" stop-color="#f1f6f9" />
+            <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
+          </linearGradient>
+        </defs>
+        <g data-name="blob-shape (3)">
+          <path class="blob" fill="url(#d)"
+            d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+        </g>
+      </svg>
+    </div>
+    <div class="animate-pattern">
+      <img src={{ "images/service/background-pattern.svg" | absURL }} alt="background-shape">
+    </div>
+    </div>
+  </section>
 
 {{ end }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,7 +2,8 @@
 
 <header class="breadCrumb">
 	<div class="svg-img">
-		<img src="images/hero/figure-svg.svg" alt="">
+
+		<img src={{"images/hero/figure-svg.svg" | absURL }} alt="">
 	</div>
 	<div class="animate-shape">
 		<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -24,19 +24,22 @@
         <i class="fa fa-clock-o"></i> &ensp;
         {{ .ReadingTime }} mins read
       </div>
-
+      {{ if .Params.tags }}
       <div class="col-lg-10 col-md-12 offset-lg-1 offset-md-0 text-center">
         <i class="fa fa-tag"></i> &ensp;
         {{ range (.GetTerms "tags") }}
         <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>;
         {{ end }}
       </div>
+      {{ end }}
+      {{ if .Params.categories }}
       <div class="col-lg-10 col-md-12 offset-lg-1 offset-md-0 text-center">
         <i class="fa fa-folder-open"></i> &ensp;
         {{ range (.GetTerms "categories") }}
         <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>;
         {{ end }}
       </div>
+      {{ end }}
     </div>
   </div>
   </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -80,6 +80,11 @@
     <div class="row mt-5">
       <div class="col-lg-12">
         <div class="singleBlog__content">
+
+          {{ if .Params.toc }}
+          <h3>Table of Contents</h3>
+          {{ .TableOfContents | replaceRE "<ul>[[:space:]]*<li>[[:space:]]*<ul>" "<ul>" | replaceRE "</ul>[[:space:]]*</li>[[:space:]]*</ul>" "</ul>" |  safeHTML }}
+          {{ end }}
           {{ .Content }}
         </div>
       </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -14,46 +14,73 @@
         </nav>
       </div>
     </div>
+
+    <div class="row p-3">
+      <div class="col-lg-10 col-md-10 offset-lg-1 offset-md-0 text-center">
+        <i class="fa fa-calendar"></i> &ensp;
+        {{ .PublishDate.Format "January 2, 2006" }}
+      </div>
+      <div class="col-lg-10 col-md-12 offset-lg-1 offset-md-0 text-center">
+        <i class="fa fa-clock-o"></i> &ensp;
+        {{ .ReadingTime }} mins read
+      </div>
+
+      <div class="col-lg-10 col-md-12 offset-lg-1 offset-md-0 text-center">
+        <i class="fa fa-tag"></i> &ensp;
+        {{ range (.GetTerms "tags") }}
+        <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>;
+        {{ end }}
+      </div>
+      <div class="col-lg-10 col-md-12 offset-lg-1 offset-md-0 text-center">
+        <i class="fa fa-folder-open"></i> &ensp;
+        {{ range (.GetTerms "categories") }}
+        <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>;
+        {{ end }}
+      </div>
+    </div>
+  </div>
+  </div>
+  </div>
   </div>
 </header>
 
 <section class="section singleBlog">
   <div class="svg-img">
-      <img src={{ "images/hero/figure-svg.svg" | absURL }} alt="">
+    <img src={{ "images/hero/figure-svg.svg" | absURL }} alt="">
   </div>
   <div class="animate-shape">
-      <!-- <img src="images/skill/skill-background-shape.svg" alt="background-shape"> -->
-      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
-          <defs>
-              <linearGradient id="d" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
-                  <stop offset="0" stop-color="#f1f6f9" />
-                  <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
-              </linearGradient>
-          </defs>
-          <g data-name="blob-shape (3)">
-              <path class="blob" fill="url(#d)"
-                  d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
-          </g>
-      </svg>
+    <img src={{ "images/skill/skill-background-shape.svg" | absURL }} alt="">
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
+      <defs>
+        <linearGradient id="d" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
+          <stop offset="0" stop-color="#f1f6f9" />
+          <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
+        </linearGradient>
+      </defs>
+      <g data-name="blob-shape (3)">
+        <path class="blob" fill="url(#d)"
+          d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+      </g>
+    </svg>
   </div>
   <div class="animate-pattern">
-      <img src={{ "images/service/background-pattern.svg" | absURL }} alt="background-shape">
+    <img src={{ "images/service/background-pattern.svg" | absURL }} alt="background-shape">
   </div>
   <div class="container">
-      <div class="row">
-          <div class="col-lg-12">
-              <div class="singleBlog__feature">
-                  <img src={{ .Params.postImage | absURL }} alt="feature-image">
-              </div>
-          </div>
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="singleBlog__feature">
+          <img src={{ .Params.postImage | absURL }} alt="feature-image">
+        </div>
       </div>
-      <div class="row mt-5">
-          <div class="col-lg-12">
-              <div class="singleBlog__content">
-                  {{ .Content }}
-              </div>
-          </div>
+    </div>
+    <div class="row mt-5">
+      <div class="col-lg-12">
+        <div class="singleBlog__content">
+          {{ .Content }}
+        </div>
       </div>
+    </div>
   </div>
 </section>
 

--- a/layouts/categories/taxonomy.html
+++ b/layouts/categories/taxonomy.html
@@ -27,8 +27,7 @@
        <h3 class="breadCrumb__title">{{ .Title }}</h3>
        <nav aria-label="breadcrumb" class="d-flex justify-content-center">
          <ol class="breadcrumb align-items-center">
-           <li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
-           <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
+          Showing all posts with the category "{{.Title}}"
          </ol>
        </nav>
      </div>

--- a/layouts/categories/taxonomy.html
+++ b/layouts/categories/taxonomy.html
@@ -1,0 +1,63 @@
+{{ define "main" }}
+
+<header class="breadCrumb">
+ <div class="svg-img">
+   <img src="images/hero/figure-svg.svg" alt="">
+ </div>
+ <div class="animate-shape">
+   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
+     <defs>
+       <linearGradient id="d" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
+         <stop offset="0" stop-color="#f1f6f9" />
+         <stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
+       </linearGradient>
+     </defs>
+     <g data-name="blob-shape (3)">
+       <path class="blob" fill="url(#d)"
+         d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+     </g>
+   </svg>
+ </div>
+ <div class="animate-pattern">
+   <img src={{"images/service/background-pattern.svg" | absURL }} alt="background-shape">
+ </div>
+ <div class="container">
+   <div class="row">
+     <div class="col-12 text-center">
+       <h3 class="breadCrumb__title">{{ .Title }}</h3>
+       <nav aria-label="breadcrumb" class="d-flex justify-content-center">
+         <ol class="breadcrumb align-items-center">
+           <li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+           <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
+         </ol>
+       </nav>
+     </div>
+   </div>
+ </div>
+</header>
+
+
+<section class="section blog-page">
+	<div class="container">
+		<div class="row">
+			{{ range .Paginator.Pages }}
+			<div class="col-lg-4">
+				<div class="blog-page__item">
+					<div class="blog-page__item-thumb">
+						<img src="{{ .Params.featureImage | absURL }}" alt="post-image">
+					</div>
+					<div class="blog-page__item-content bg-white">
+						<span class="small">{{ .PublishDate.Format "January 2, 2006" }}</span>
+						<h5 class="mb-0">
+							<a class="text-dark" href="{{ .Permalink }}">{{ .Title }}</a>
+						</h5>
+					</div>
+				</div>
+			</div>
+			{{ end }}
+			{{ partial "pagination" .}}
+		</div>
+	</div>
+</section>
+{{ end }}
+

--- a/layouts/categories/taxonomy.html
+++ b/layouts/categories/taxonomy.html
@@ -2,7 +2,7 @@
 
 <header class="breadCrumb">
  <div class="svg-img">
-   <img src="images/hero/figure-svg.svg" alt="">
+  <img src={{"images/hero/figure-svg.svg" | absURL }} alt="">
  </div>
  <div class="animate-shape">
    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">

--- a/layouts/tags/taxonomy.html
+++ b/layouts/tags/taxonomy.html
@@ -2,7 +2,7 @@
 
  <header class="breadCrumb">
 	<div class="svg-img">
-		<img src="images/hero/figure-svg.svg" alt="">
+		<img src={{"images/hero/figure-svg.svg" | absURL }} alt="">
 	</div>
 	<div class="animate-shape">
 		<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">

--- a/layouts/tags/taxonomy.html
+++ b/layouts/tags/taxonomy.html
@@ -1,0 +1,63 @@
+ {{ define "main" }}
+
+ <header class="breadCrumb">
+	<div class="svg-img">
+		<img src="images/hero/figure-svg.svg" alt="">
+	</div>
+	<div class="animate-shape">
+		<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">
+			<defs>
+				<linearGradient id="d" x1="0.929" y1="0.111" x2="0.263" y2="0.935" gradientUnits="objectBoundingBox">
+					<stop offset="0" stop-color="#f1f6f9" />
+					<stop offset="1" stop-color="#f1f6f9" stop-opacity="0" />
+				</linearGradient>
+			</defs>
+			<g data-name="blob-shape (3)">
+				<path class="blob" fill="url(#d)"
+					d="M455.4 151.1c43.1 36.7 73.4 92.8 60.8 136.3-12.7 43.5-68.1 74.4-111.3 119.4-43.1 45-74 104.1-109.8 109-35.9 5-76.7-44.2-111.8-89.2-35.2-45-64.7-85.8-70.8-132.6-6-46.8 11.6-99.6 46.7-136.3 35.2-36.6 88-57.2 142.4-58.8 54.5-1.7 110.6 15.6 153.8 52.2z" />
+			</g>
+		</svg>
+	</div>
+	<div class="animate-pattern">
+		<img src={{"images/service/background-pattern.svg" | absURL }} alt="background-shape">
+	</div>
+	<div class="container">
+		<div class="row">
+			<div class="col-12 text-center">
+				<h3 class="breadCrumb__title">{{ .Title }}</h3>
+				<nav aria-label="breadcrumb" class="d-flex justify-content-center">
+					<ol class="breadcrumb align-items-center">
+						<li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+						<li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
+					</ol>
+				</nav>
+			</div>
+		</div>
+	</div>
+</header>
+
+
+<section class="section blog-page">
+	<div class="container">
+		<div class="row">
+			{{ range .Paginator.Pages }}
+			<div class="col-lg-4">
+				<div class="blog-page__item">
+					<div class="blog-page__item-thumb">
+						<img src="{{ .Params.featureImage | absURL }}" alt="post-image">
+					</div>
+					<div class="blog-page__item-content bg-white">
+						<span class="small">{{ .PublishDate.Format "January 2, 2006" }}</span>
+						<h5 class="mb-0">
+							<a class="text-dark" href="{{ .Permalink }}">{{ .Title }}</a>
+						</h5>
+					</div>
+				</div>
+			</div>
+			{{ end }}
+			{{ partial "pagination" .}}
+		</div>
+	</div>
+</section>
+{{ end }}
+

--- a/layouts/tags/taxonomy.html
+++ b/layouts/tags/taxonomy.html
@@ -27,8 +27,7 @@
 				<h3 class="breadCrumb__title">{{ .Title }}</h3>
 				<nav aria-label="breadcrumb" class="d-flex justify-content-center">
 					<ol class="breadcrumb align-items-center">
-						<li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
-						<li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
+						Showing all posts with the tag "{{.Title}}"
 					</ol>
 				</nav>
 			</div>


### PR DESCRIPTION
This PR adds support for taxonomies (tags and categories) for blog posts.
Also added the blog post date and reading time on blog post header. Also added table of contents at the beginning of the blog post.

Attached is the screenshot
![image](https://user-images.githubusercontent.com/6821286/154794174-23bcc622-fcf8-484b-a15f-78d980c8f503.png)
