### PR TITLE
Remove `.Site.BaseURL`

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -28,7 +28,7 @@
 				<h3 class="breadCrumb__title">{{ .Title }}</h3>
 				<nav aria-label="breadcrumb" class="d-flex justify-content-center">
 					<ol class="breadcrumb align-items-center">
-						<li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+						<li class="breadcrumb-item"><a href="{{ .Site.Home.Permalink }}">Home</a></li>
 						<li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
 					</ol>
 				</nav>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -7,7 +7,7 @@
         <h3 class="breadCrumb__title">{{ .Title }}</h3>
         <nav aria-label="breadcrumb" class="d-flex justify-content-center">
           <ol class="breadcrumb align-items-center">
-            <li class="breadcrumb-item"><a href={{ .Site.BaseURL }}>Home</a></li>
+            <li class="breadcrumb-item"><a href={{ .Site.Home.Permalink }}>Home</a></li>
             <li class="breadcrumb-item"><a href={{ .Site.Params.blogPageURL | absURL }}>All Post</a></li>
             <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
           </ol>

--- a/layouts/contact/list.html
+++ b/layouts/contact/list.html
@@ -27,7 +27,7 @@
         <h3 class="breadCrumb__title">{{ .Title }}</h3>
         <nav aria-label="breadcrumb" class="d-flex justify-content-center">
           <ol class="breadcrumb align-items-center">
-            <li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+            <li class="breadcrumb-item"><a href="{{ .Site.Home.Permalink}}">Home</a></li>
             <li class="breadcrumb-item active" aria-current="page">{{ .Params.breadcrumb }}</li>
           </ol>
         </nav>
@@ -175,8 +175,6 @@
             </div>
             <button type="submit" class="btn btn-primary">Sign in</button>
           </form> -->
-
-
 
         </div>
       </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg fixed-top">
   <div class="container">
-    <a href="{{ .Site.BaseURL }}" class="navbar-brand">
+    <a href="{{ .Site.Home.Permalink }}" class="navbar-brand">
       <img src="{{ .Site.Params.logo | absURL }}" alt="site-logo">
     </a>
     <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbarCollapse">
@@ -14,7 +14,7 @@
         {{ $menu := .Site.Menus.main }}
         {{ range $index, $element := $menu }}
         <li class="nav-item">
-          <a href="{{ $.Site.BaseURL }}{{ .URL }}"
+          <a href="{{ $.Site.Home.Permalink }}{{ .URL }}"
             class="nav-link text-dark text-sm-center p-2 {{ if $.IsHome }}scroll{{ end }}">{{ .Name }}</a>
         </li>
         {{ end }}


### PR DESCRIPTION
> There is never a great reason to call .Site.BaseURL from a template. Hopefully we will deprecate that method at some point. Use the `absURL` and `absLangURL` functions instead.

[JMooring](https://discourse.gohugo.io/t/46692/4)

https://gohugo.io/methods/site/home/

